### PR TITLE
v1.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,9 +83,10 @@ second argument, `payload`, requires an JSON encoded string.
 This example publishes to an MQTT topic:
 
 ``` emacs-lisp
-(hass-call-service-with-payload "mqtt.publish"
-                                (json-encode '(("payload" . "PERFORM")
-                                               ("topic" . "valetudo/vacuum/LocateCapability/locate/set"))))
+(hass-call-service-with-payload
+ "mqtt.publish"
+ (json-encode '(("payload" . "PERFORM")
+                ("topic" . "valetudo/vacuum/LocateCapability/locate/set"))))
 ```
 
 You could pass a JSON string directly, but that would require escaping every quote which can be

--- a/README.md
+++ b/README.md
@@ -75,6 +75,29 @@ function which has two required arguments: `entity-id` and `service`.
 If you call `hass-call-service` interactively, it will prompt you for an
 entity ID and then the respective service you want to call.
 
+### Payloads
+
+For services that require additional data use the ~hass-call-service-with-payload~ function. The
+second argument, `payload`, requires an JSON encoded string.
+
+This example publishes to an MQTT topic:
+
+``` emacs-lisp
+(hass-call-service-with-payload "mqtt.publish"
+                                (json-encode '(("payload" . "PERFORM")
+                                               ("topic" . "valetudo/vacuum/LocateCapability/locate/set"))))
+```
+
+You could pass a JSON string directly, but that would require escaping every quote which can be
+cumbersome. Here's what the encoded list above looks like in JSON:
+
+``` javascript
+{
+  "payload": "PERFORM",
+  "topic": "valetudo/vacuum/LocateCapability/locate/set"
+}
+```
+
 ### Auto-query
 
 Auto-querying is a recurring query to the Home Assistant instance to get

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ To call a service on Home Assistant, use the `hass-call-service`
 function which has two required arguments: `entity-id` and `service`.
 
 ``` emacs-lisp
-(hass-call-service "switch.bedroom_light" "toggle")
+(hass-call-service "switch.bedroom_light" "switch.toggle")
 ```
 
 If you call `hass-call-service` interactively, it will prompt you for an

--- a/README.md
+++ b/README.md
@@ -83,10 +83,9 @@ second argument, `payload`, requires an JSON encoded string.
 This example publishes to an MQTT topic:
 
 ``` emacs-lisp
-(hass-call-service-with-payload
- "mqtt.publish"
- (json-encode '(("payload" . "PERFORM")
-                ("topic" . "valetudo/vacuum/LocateCapability/locate/set"))))
+(hass-call-service-with-payload "mqtt.publish"
+                                (json-encode '(("payload" . "PERFORM")
+                                               ("topic" . "valetudo/vacuum/LocateCapability/locate/set"))))
 ```
 
 You could pass a JSON string directly, but that would require escaping every quote which can be

--- a/README.org
+++ b/README.org
@@ -78,9 +78,10 @@ second argument, ~payload~, requires an JSON encoded string.
 This example publishes to an MQTT topic:
 
 #+BEGIN_SRC emacs-lisp :results none
-(hass-call-service-with-payload "mqtt.publish"
-                                (json-encode '(("payload" . "PERFORM")
-                                               ("topic" . "valetudo/vacuum/LocateCapability/locate/set"))))
+(hass-call-service-with-payload
+ "mqtt.publish"
+ (json-encode '(("payload" . "PERFORM")
+                ("topic" . "valetudo/vacuum/LocateCapability/locate/set"))))
 #+END_SRC
 
 You could pass a JSON string directly, but that would require escaping every quote which can be

--- a/README.org
+++ b/README.org
@@ -3,7 +3,7 @@
 
 * Installation
 ** straight.el
-#+BEGIN_SRC emacs-lisp
+#+BEGIN_SRC emacs-lisp :results none
 (straight-use-package
   '(hass
     :type git
@@ -21,7 +21,7 @@ Place in your ~packages.el~ to pull the repository.
 #+END_SRC
 
 Then load the package in your main config file.
-#+BEGIN_SRC emacs-lisp
+#+BEGIN_SRC emacs-lisp :results none
 (use-package! hass)
 #+END_SRC
 
@@ -55,7 +55,7 @@ page.
 To call a service on Home Assistant, use the ~hass-call-service~ function which has two required
 arguments: ~entity-id~ and ~service~.
 
-#+BEGIN_SRC emacs-lisp
+#+BEGIN_SRC emacs-lisp :results none
 (hass-call-service "switch.bedroom_light" "switch.toggle")
 #+END_SRC
 
@@ -95,7 +95,7 @@ The other two hooks available are ~hass-entity-state-updated-hook~ and
 is updated, regardless of if it changed or not. ~hass-service-called-hook~ is called when a service
 is called.
 
-#+BEGIN_SRC emacs-lisp
+#+BEGIN_SRC emacs-lisp :results none
 (add-hook 'hass-service-called-hook (lambda () (message "A service was called.")))
 (add-hook 'hass-entity-state-updated-hook (lambda () (message "An entitys' state was updated.")))
 #+END_SRC

--- a/README.org
+++ b/README.org
@@ -62,6 +62,29 @@ arguments: ~entity-id~ and ~service~.
 If you call ~hass-call-service~ interactively, it will prompt you for an entity ID and then the
 respective service you want to call.
 
+** Payloads
+
+For services that require additional data use the ~hass-call-service-with-payload~ function. The
+second argument, ~payload~, requires an JSON encoded string.
+
+This example publishes to an MQTT topic:
+
+#+BEGIN_SRC emacs-lisp :results none
+(hass-call-service-with-payload "mqtt.publish"
+                                (json-encode '(("payload" . "PERFORM")
+                                               ("topic" . "valetudo/vacuum/LocateCapability/locate/set"))))
+#+END_SRC
+
+You could pass a JSON string directly, but that would require escaping every quote which can be
+cumbersome. Here's what the encoded list above looks like in JSON:
+
+#+BEGIN_SRC javascript
+{
+  "payload": "PERFORM",
+  "topic": "valetudo/vacuum/LocateCapability/locate/set"
+}
+#+END_SRC
+
 ** Auto-query
 Auto-querying is a recurring query to the Home Assistant instance to get the current state of some
 entities. The list of entity IDs that will be queried are found in the variable ~hass-auto-entities~.

--- a/README.org
+++ b/README.org
@@ -3,7 +3,6 @@
 
 * Installation
 ** straight.el
-
 #+BEGIN_SRC emacs-lisp :results none
 (straight-use-package
   '(hass
@@ -13,9 +12,7 @@
 #+END_SRC
 
 ** Doom Emacs
-
 Place in your ~packages.el~ to pull the repository.
-
 #+BEGIN_SRC emacs-lisp :results none
 (package! hass
   :recipe
@@ -24,15 +21,12 @@ Place in your ~packages.el~ to pull the repository.
 #+END_SRC
 
 Then load the package in your main config file.
-
 #+BEGIN_SRC emacs-lisp :results none
 (use-package! hass)
 #+END_SRC
 
 * Configuration
-
 Both ~hass-url~ and ~hass-apikey~ must be set to use this package
-
 #+BEGIN_SRC emacs-lisp :results none
 (setq hass-url "https://192.168.1.10:8123"
       hass-apikey "APIKEY-GOES-IN-HERE")
@@ -40,7 +34,6 @@ Both ~hass-url~ and ~hass-apikey~ must be set to use this package
 
 Alternatively, you can store a function inside ~hass-apikey~. This will be executed on every
 query.
-
 #+BEGIN_SRC emacs-lisp :results none
 (setq hass-apikey (lambda () (auth-source-pass-get 'secret "home/hass/emacs-apikey")))
 #+END_SRC
@@ -59,7 +52,6 @@ and going to your profile by selecting your username in the lower-left corner or
 page.
 
 * Usage
-
 To call a service on Home Assistant, use the ~hass-call-service~ function which has two required
 arguments: ~entity-id~ and ~service~.
 
@@ -78,10 +70,9 @@ second argument, ~payload~, requires an JSON encoded string.
 This example publishes to an MQTT topic:
 
 #+BEGIN_SRC emacs-lisp :results none
-(hass-call-service-with-payload
- "mqtt.publish"
- (json-encode '(("payload" . "PERFORM")
-                ("topic" . "valetudo/vacuum/LocateCapability/locate/set"))))
+(hass-call-service-with-payload "mqtt.publish"
+                                (json-encode '(("payload" . "PERFORM")
+                                               ("topic" . "valetudo/vacuum/LocateCapability/locate/set"))))
 #+END_SRC
 
 You could pass a JSON string directly, but that would require escaping every quote which can be
@@ -95,7 +86,6 @@ cumbersome. Here's what the encoded list above looks like in JSON:
 #+END_SRC
 
 ** Auto-query
-
 Auto-querying is a recurring query to the Home Assistant instance to get the current state of some
 entities. The list of entity IDs that will be queried are found in the variable ~hass-auto-entities~.
 
@@ -117,7 +107,6 @@ has changed since it was last updated. Using this function hook along side [[*Au
 Emacs to react to changes to Home Assistant entities.
 
 This example will display the state of an entity when it changes:
-
 #+BEGIN_SRC emacs-lisp :results none
 (add-hook 'hass-entity-state-updated-functions
   (lambda (entity-id)

--- a/README.org
+++ b/README.org
@@ -3,6 +3,7 @@
 
 * Installation
 ** straight.el
+
 #+BEGIN_SRC emacs-lisp :results none
 (straight-use-package
   '(hass
@@ -12,7 +13,9 @@
 #+END_SRC
 
 ** Doom Emacs
+
 Place in your ~packages.el~ to pull the repository.
+
 #+BEGIN_SRC emacs-lisp :results none
 (package! hass
   :recipe
@@ -21,12 +24,15 @@ Place in your ~packages.el~ to pull the repository.
 #+END_SRC
 
 Then load the package in your main config file.
+
 #+BEGIN_SRC emacs-lisp :results none
 (use-package! hass)
 #+END_SRC
 
 * Configuration
+
 Both ~hass-url~ and ~hass-apikey~ must be set to use this package
+
 #+BEGIN_SRC emacs-lisp :results none
 (setq hass-url "https://192.168.1.10:8123"
       hass-apikey "APIKEY-GOES-IN-HERE")
@@ -34,6 +40,7 @@ Both ~hass-url~ and ~hass-apikey~ must be set to use this package
 
 Alternatively, you can store a function inside ~hass-apikey~. This will be executed on every
 query.
+
 #+BEGIN_SRC emacs-lisp :results none
 (setq hass-apikey (lambda () (auth-source-pass-get 'secret "home/hass/emacs-apikey")))
 #+END_SRC
@@ -52,6 +59,7 @@ and going to your profile by selecting your username in the lower-left corner or
 page.
 
 * Usage
+
 To call a service on Home Assistant, use the ~hass-call-service~ function which has two required
 arguments: ~entity-id~ and ~service~.
 
@@ -70,9 +78,10 @@ second argument, ~payload~, requires an JSON encoded string.
 This example publishes to an MQTT topic:
 
 #+BEGIN_SRC emacs-lisp :results none
-(hass-call-service-with-payload "mqtt.publish"
-                                (json-encode '(("payload" . "PERFORM")
-                                               ("topic" . "valetudo/vacuum/LocateCapability/locate/set"))))
+(hass-call-service-with-payload
+ "mqtt.publish"
+ (json-encode '(("payload" . "PERFORM")
+                ("topic" . "valetudo/vacuum/LocateCapability/locate/set"))))
 #+END_SRC
 
 You could pass a JSON string directly, but that would require escaping every quote which can be
@@ -86,6 +95,7 @@ cumbersome. Here's what the encoded list above looks like in JSON:
 #+END_SRC
 
 ** Auto-query
+
 Auto-querying is a recurring query to the Home Assistant instance to get the current state of some
 entities. The list of entity IDs that will be queried are found in the variable ~hass-auto-entities~.
 
@@ -107,6 +117,7 @@ has changed since it was last updated. Using this function hook along side [[*Au
 Emacs to react to changes to Home Assistant entities.
 
 This example will display the state of an entity when it changes:
+
 #+BEGIN_SRC emacs-lisp :results none
 (add-hook 'hass-entity-state-updated-functions
   (lambda (entity-id)

--- a/README.org
+++ b/README.org
@@ -56,7 +56,7 @@ To call a service on Home Assistant, use the ~hass-call-service~ function which 
 arguments: ~entity-id~ and ~service~.
 
 #+BEGIN_SRC emacs-lisp
-(hass-call-service "switch.bedroom_light" "toggle")
+(hass-call-service "switch.bedroom_light" "switch.toggle")
 #+END_SRC
 
 If you call ~hass-call-service~ interactively, it will prompt you for an entity ID and then the

--- a/hass.el
+++ b/hass.el
@@ -282,16 +282,16 @@ ENTITY-ID.  (e.g. `\"turn_off\"')"
             (format "%s.%s"
                     (hass--domain-of-entity entity)
                     (completing-read (format "%s: " entity) (hass--services-for-entity entity) nil t)))))
-  (hass--call-service
+  (hass-call-service-with-payload
    service
    (format "{\"entity_id\": \"%s\"}" entity-id)
-   (lambda (&rest _) (run-hooks 'hass-service-called-hook) (hass--get-entity-state entity-id))))
+   (lambda (&rest _) (hass--get-entity-state entity-id))))
 
-(defun hass-call-service-with-payload (service payload)
+(defun hass-call-service-with-payload (service payload &optional callback)
   (hass--call-service
    service
    payload
-   (lambda (&rest _) (run-hooks 'hass-service-called-hook))))
+   (lambda (&rest _) (run-hooks 'hass-service-called-hook) (funcall callback))))
 
 
 ;; Auto query

--- a/hass.el
+++ b/hass.el
@@ -262,20 +262,16 @@ ENTITY-ID is a string of the entity_id in Home Assistant."
                  payload))
 
 (defun hass-call-service (entity-id service)
-  "Call service SERVICE for ENTITY-ID on the Home Assistant server.
+  "Call service for an entity on Home Assistant.
 If called interactively, prompt the user for an ENTITY-ID and
 SERVICE to call.
 
 This will send an API request to the url configure in `hass-url'.
 
-This function requires both ENTITY-ID and SERVICE keyword
-arguments to be passed.
-
 ENTITY-ID is a string of the entity id in Home Assistant you want
 to call the service on.  (e.g. `\"switch.kitchen_light\"').
 
-SERVICE is the service you want to call on
-ENTITY-ID.  (e.g. `\"turn_off\"')"
+SERVICE is the service you want to call on ENTITY-ID.  (e.g. `\"turn_off\"')"
   (interactive
     (let ((entity (completing-read "Entity: " hass--available-entities nil t)))
       (list entity
@@ -288,6 +284,14 @@ ENTITY-ID.  (e.g. `\"turn_off\"')"
    (lambda (&rest _) (hass--get-entity-state entity-id))))
 
 (defun hass-call-service-with-payload (service payload &optional callback)
+  "Call service with a custom payload on Home Assistant.
+This will send an API request to the url configure in `hass-url'.
+
+SERVICE is a string of the Home Assistant service to be called.
+
+PAYLOAD is a JSON-encoded string of the payload to be sent with SERVICE.
+
+CALLBACK is an optional function to be called after the service call is sent."
   (hass--call-service
    service
    payload

--- a/hass.el
+++ b/hass.el
@@ -261,7 +261,7 @@ ENTITY-ID is a string of the entity_id in Home Assistant."
                  success-callback
                  payload))
 
-(defun hass-call-service (entity-id service &optional payload)
+(defun hass-call-service (entity-id service)
   "Call service SERVICE for ENTITY-ID on the Home Assistant server.
 If called interactively, prompt the user for an ENTITY-ID and
 SERVICE to call.
@@ -282,12 +282,16 @@ ENTITY-ID.  (e.g. `\"turn_off\"')"
             (format "%s.%s"
                     (hass--domain-of-entity entity)
                     (completing-read (format "%s: " entity) (hass--services-for-entity entity) nil t)))))
+  (hass--call-service
+   service
+   (format "{\"entity_id\": \"%s\"}" entity-id)
+   (lambda (&rest _) (run-hooks 'hass-service-called-hook) (hass--get-entity-state entity-id))))
 
-  (hass--call-service service
-      (or payload (format "{\"entity_id\": \"%s\"}" entity-id))
-      (lambda (&rest _)
-        (run-hooks 'hass-service-called-hook)
-        (hass--get-entity-state entity-id))))
+(defun hass-call-service-with-payload (service payload)
+  (hass--call-service
+   service
+   payload
+   (lambda (&rest _) (run-hooks 'hass-service-called-hook))))
 
 
 ;; Auto query

--- a/hass.el
+++ b/hass.el
@@ -282,7 +282,7 @@ ENTITY-ID is a string of the entity_id in Home Assistant."
                  success-callback
                  payload))
 
-(defun hass-call-service-on-entity (entity-id service)
+(defun hass-call-service (entity-id service &optional payload)
   "Call service SERVICE for ENTITY-ID on the Home Assistant server.
 
 If called interactively, prompt the user for an ENTITY-ID and
@@ -306,10 +306,10 @@ ENTITY-ID.  (e.g. `\"turn_off\"')"
                                              (hass--services-for-entity entity) nil t)))))
 
   (hass--call-service service
-                      (format "{\"entity_id\": \"%s\"}" entity-id)
-                      #'(lambda (&rest _)
-                          (run-hooks 'hass-service-called-hook)
-                          (hass--get-entity-state entity-id))))
+      (or payload (format "{\"entity_id\": \"%s\"}" entity-id))
+      #'(lambda (&rest _)
+          (run-hooks 'hass-service-called-hook)
+          (hass--get-entity-state entity-id))))
 
 
 ;; Auto query

--- a/hass.el
+++ b/hass.el
@@ -295,7 +295,7 @@ CALLBACK is an optional function to be called after the service call is sent."
   (hass--call-service
    service
    payload
-   (lambda (&rest _) (run-hooks 'hass-service-called-hook) (funcall callback))))
+   (lambda (&rest _) (run-hooks 'hass-service-called-hook) (when callback (funcall callback)))))
 
 
 ;; Auto query

--- a/hass.el
+++ b/hass.el
@@ -26,7 +26,6 @@
 ;; Customizable
 (defcustom hass-url nil
   "The URL of the Home Assistant instance.
-
 Set this to the URL of the Home Assistant instance you want to
 control.  (e.g. https://192.168.1.10:8123)"
   :group 'hass
@@ -34,7 +33,6 @@ control.  (e.g. https://192.168.1.10:8123)"
 
 (defcustom hass-apikey nil
   "API key used for Home Assistant queries.
-
 The key generated from the Home Assistant instance used to authorize API
 requests"
   :group 'hass
@@ -42,7 +40,6 @@ requests"
 
 (defcustom hass-auto-entities nil
   "A list of tracked Home Assistant entities.
-
 Set this to a list of Home Assistant entity ID strings.  An entity ID looks
 something like *switch.bedroom_light*."
 
@@ -63,7 +60,6 @@ something like *switch.bedroom_light*."
 ;; Hooks
 (defvar hass-entity-state-updated-functions nil
  "List of functions called when an entity state changes.
-
 Each function is called with one arguments: the ENTITY-ID of the
 entity whose state changed.")
 
@@ -94,7 +90,6 @@ entity whose state changed.")
 ;; Helper functions
 (defun hass--apikey ()
   "Return the effective apikey.
-
 If HASS-APIKEY is a function, execute it to get value.  Otherwise
 return HASS-APIKEY as is."
   (if (functionp hass-apikey)
@@ -103,13 +98,11 @@ return HASS-APIKEY as is."
 
 (defun hass--entity-url (entity-id)
   "Generate entity state endpoint URLs.
-
 ENTITY-ID is a string of the entities ID."
   (format "%s/%s/%s" hass-url "api/states" entity-id))
 
 (defun hass--service-url (service)
   "Generate service endpoint URL.
-
 SERVICE is a string of the service to call."
   (let* ((parts (split-string service "\\."))
          (domain (pop parts))
@@ -132,7 +125,6 @@ SERVICE is a string of the service to call."
 ;; API parsing
 (defun hass--parse-all-entities (entities)
   "Convert entity state data into a list of available entities.
-
 ENTITIES is the data returned from the `/api/states' endpoint."
   (delq nil (mapcar (lambda (entity)
                       (hass--parse-entity entity))
@@ -140,7 +132,6 @@ ENTITIES is the data returned from the `/api/states' endpoint."
 
 (defun hass--parse-entity (entity-state)
   "Convert an entity's state data into its entity-id.
-
 ENTITY-STATE is an individual entity state data return from the
 `/api/states' endpoint.
 
@@ -151,13 +142,11 @@ Only returns entities that have callable services available."
 
 (defun hass--parse-all-domains (domains)
   "Collect DOMAINS into an alist of their associated services.
-
 DOMAINS is the data returned from the `/api/services' endpoint."
   (mapcar #'hass--parse-domain domains))
 
 (defun hass--parse-domain (domain)
   "Convert DOMAIN into cons cell of its available list of services.
-
 DOMAIN is a single domain return from the `/api/services'
 endpoint."
   (cons (cdr (assoc 'domain domain))
@@ -177,14 +166,12 @@ endpoint."
 
 (defun hass--get-available-services-result (domains)
   "Callback when all service information is received from API.
-
 DOMAINS is the response from the `/api/services' endpoint which
 returns a list of domains and their available services."
   (setq hass--available-services (hass--parse-all-domains domains)))
 
 (defun hass--query-entity-result (entity-id state)
   "Callback when an entity state data is received from API.
-
 ENTITY-ID is the id of the entity that has STATE."
   (let ((previous-state (hass-state-of entity-id)))
     (setf (alist-get entity-id hass--states nil nil 'string-match-p) state)
@@ -194,14 +181,12 @@ ENTITY-ID is the id of the entity that has STATE."
 
 (defun hass--call-service-result (entity-id state)
   "Callback when a successful service request is received from API.
-
 ENTITY-ID is the id of the entity that was affected and now has STATE."
   (setf (alist-get entity-id hass--states nil nil 'string-match-p) state)
   (run-hooks 'hass-service-called-hook))
 
 (cl-defun hass--request-error (&key error-thrown &allow-other-keys)
   "Error handler for invalid requests.
-
 ERROR-THROWN is the error thrown from the request.el request."
 
   (let ((error (cdr error-thrown)))
@@ -217,7 +202,6 @@ ERROR-THROWN is the error thrown from the request.el request."
 ;; Requests
 (defun hass--request (type url &optional success payload)
   "Function to reduce a lot of boilerplate when making a request.
-
 TYPE is a string of the type of request to make. For example, `\"GET\"'.
 
 URL is a string of URL of the request.
@@ -239,7 +223,6 @@ PAYLOAD is contents the body of the request."
 
 (defun hass--get-available-entities ()
   "Retrieve the available entities from the Home Assistant instance.
-
 Makes a request to `/api/states' but drops everything except an
 list of entity-ids."
   (hass--request "GET" (concat hass-url "/api/states")
@@ -258,7 +241,6 @@ list of entity-ids."
 
 (defun hass--get-entity-state (entity-id)
   "Retrieve the current state of ENTITY-ID from the Home Assistant server.
-
 This function is just for sending the actual API request."
   (hass--request "GET" (hass--entity-url entity-id)
     (cl-function
@@ -268,7 +250,6 @@ This function is just for sending the actual API request."
 
 (defun hass--call-service (service payload &optional success-callback)
   "Call service SERVICE for ENTITY-ID on the Home Assistant server.
-
 This function is just for building and sending the actual API request.
 
 DOMAIN is a string for the domain in Home Assistant this service is apart of.
@@ -284,7 +265,6 @@ ENTITY-ID is a string of the entity_id in Home Assistant."
 
 (defun hass-call-service (entity-id service &optional payload)
   "Call service SERVICE for ENTITY-ID on the Home Assistant server.
-
 If called interactively, prompt the user for an ENTITY-ID and
 SERVICE to call.
 
@@ -315,7 +295,6 @@ ENTITY-ID.  (e.g. `\"turn_off\"')"
 ;; Auto query
 (defun hass-auto-query-toggle ()
   "Toggle querying Home Assistant periodically.
-
 Auto-querying is a way to periodically query the state of
 entities you want to hook into to capture when their state
 changes.
@@ -362,7 +341,6 @@ to query automatically."
 ;;;###autoload
 (define-minor-mode hass-mode
   "Toggle hass-mode.
-
 Key bindings:
 \\{hass-mode-map}"
   :lighter nil

--- a/hass.el
+++ b/hass.el
@@ -1,7 +1,7 @@
 ;;; hass.el --- Interact with Home Assistant -*- lexical-binding: t; -*-
 
 ;; Package-Requires: ((emacs "25.1") (request "0.3.3"))
-;; Version: 1.0
+;; Version: 1.1
 ;; Author: Ben Whitley
 ;;; Commentary:
 

--- a/hass.el
+++ b/hass.el
@@ -126,8 +126,7 @@ SERVICE is a string of the service to call."
 (defun hass--parse-all-entities (entities)
   "Convert entity state data into a list of available entities.
 ENTITIES is the data returned from the `/api/states' endpoint."
-  (delq nil (mapcar (lambda (entity)
-                      (hass--parse-entity entity))
+  (delq nil (mapcar (lambda (entity) (hass--parse-entity entity))
                     entities)))
 
 (defun hass--parse-entity (entity-state)
@@ -154,8 +153,7 @@ endpoint."
   
 (defun hass--parse-services (services)
   "Flattens the SERVICES return from `/api/services' endpoint to just the service name."
-  (mapcar #'(lambda (service)
-              (car service))
+  (mapcar (lambda (service) (car service))
           services))
 
 
@@ -281,15 +279,15 @@ ENTITY-ID.  (e.g. `\"turn_off\"')"
   (interactive
     (let ((entity (completing-read "Entity: " hass--available-entities nil t)))
       (list entity
-            (format "%s.%s" (hass--domain-of-entity entity)
-                            (completing-read (format "%s: " entity)
-                                             (hass--services-for-entity entity) nil t)))))
+            (format "%s.%s"
+                    (hass--domain-of-entity entity)
+                    (completing-read (format "%s: " entity) (hass--services-for-entity entity) nil t)))))
 
   (hass--call-service service
       (or payload (format "{\"entity_id\": \"%s\"}" entity-id))
-      #'(lambda (&rest _)
-          (run-hooks 'hass-service-called-hook)
-          (hass--get-entity-state entity-id))))
+      (lambda (&rest _)
+        (run-hooks 'hass-service-called-hook)
+        (hass--get-entity-state entity-id))))
 
 
 ;; Auto query
@@ -312,12 +310,9 @@ to query automatically."
 
 (defun hass-auto-query-enable ()
   "Enable auto-query."
-  (unless hass-mode
-    (user-error "Hass-mode must be enabled to use this feature"))
-  (when hass--timer
-    (hass--auto-query-cancel))
-  (setq hass--timer
-    (run-with-timer nil hass-auto-query-frequency 'hass-query-all-entities))
+  (unless hass-mode (user-error "Hass-mode must be enabled to use this feature"))
+  (when hass--timer (hass--auto-query-cancel))
+  (setq hass--timer (run-with-timer nil hass-auto-query-frequency 'hass-query-all-entities))
   (setq hass-auto-query t))
 
 (defun hass-auto-query-disable ()
@@ -353,12 +348,10 @@ Key bindings:
       (unless (equal (type-of hass-url) 'string)
           (hass-mode 0)
           (user-error "HASS-URL must be set to use hass-mode"))
-      (when hass-auto-query
-        (hass-auto-query-enable))
+      (when hass-auto-query (hass-auto-query-enable))
       (hass--get-available-entities)
       (hass--get-available-services))
-  (unless hass-mode
-    (hass--auto-query-cancel)))
+  (unless hass-mode (hass--auto-query-cancel)))
 
 (provide 'hass)
 


### PR DESCRIPTION
Custom payload support.

Added:
New function for custom payloads: `hass-call-service-with-payload`.

Breaking changes:
- `hass-call-service` now requires full service id.
For example, to toggle a switch you should now pass `switch.toggle` instead of just `toggle`.