### PR TITLE
v1.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ This will be executed on every query.
 (setq hass-apikey (lambda () (auth-source-pass-get 'secret "home/hass/emacs-apikey")))
 ```
 
-Once those variables are set, you must call ~(hass-setup)~ before using this package so that it can
+Once those variables are set, you must call `(hass-setup)` before using this package so that it can
 query the Home Assistance instance and populate available entities and services.
 
 ### Getting an API Key

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Both `hass-url` and `hass-apikey` must be set to use this package
 ``` emacs-lisp
 (setq hass-url "https://192.168.1.10:8123"
       hass-apikey "APIKEY-GOES-IN-HERE")
+(hass-setup)
 ```
 
 Alternatively, you can store a function inside `hass-apikey`.
@@ -47,9 +48,8 @@ This will be executed on every query.
 (setq hass-apikey (lambda () (auth-source-pass-get 'secret "home/hass/emacs-apikey")))
 ```
 
-The `hass-entity` variable is used when the `hass-query-all-entities`
-function is called. It should contain a list of strings of entity ID's
-for each entity you want included.
+Once those variables are set, you must call ~(hass-setup)~ before using this package so that it can
+query the Home Assistance instance and populate available entities and services.
 
 ### Getting an API Key
 
@@ -99,29 +99,29 @@ cumbersome. Here's what the encoded list above looks like in JSON:
 }
 ```
 
-### Auto-query
+### Watching entities
 
-Auto-querying is a recurring query to the Home Assistant instance to get
-the current state of some entities. The list of entity IDs that will be
-queried are found in the variable `hass-auto-entities`.
+`hass-watch-mode` is a mode that periodically queries the Home Assistant instance to get the current
+state of a list of entities. The list of entity IDs that will be queried are found in the variable
+`hass-watch-entities`.
 
 ``` emacs-lisp
-(setq hass-auto-entities '("switch.bedroom_light" "switch.bedroom_fan"))
+(setq hass-watched-entities '("switch.bedroom_light" "switch.bedroom_fan"))
 ```
 
 The frequency of the query can be adjusted by setting
-`hass-auto-query-frequency` to the number of seconds you'd like.
+`hass-watch-frequency` to the number of seconds you'd like.
 Defaults to 60.
 
-Auto-querying is most useful with the function hook
-`hass-entity-state-updated-functions` explained in the [Hooks](#Hooks) section.
+Watching is most useful with the function hook `hass-entity-state-updated-functions` explained in
+the [Hooks](#Hooks) section.
 
 ### Hooks
 
 The most useful hook is a function list named `hass-entity-state-updated-functions`. Functions in
 this list are passed a single argument `entity-id` which is the entity id of the entity whose state
-has changed since it was last updated. Using this function hook along side
-[auto-querying](#Auto-query) enables Emacs to react to changes to Home Assistant entities.
+has changed since it was last updated. Using this function hook along side [watching
+entities](#Watching entities) enables Emacs to react to changes to Home Assistant entities.
 
 This example will display the state of an entity when it changes:
 

--- a/README.org
+++ b/README.org
@@ -36,6 +36,7 @@ Both ~hass-url~ and ~hass-apikey~ must be set to use this package
 #+BEGIN_SRC emacs-lisp :results none
 (setq hass-url "https://192.168.1.10:8123"
       hass-apikey "APIKEY-GOES-IN-HERE")
+(hass-setup)
 #+END_SRC
 
 Alternatively, you can store a function inside ~hass-apikey~. This will be executed on every
@@ -45,8 +46,8 @@ query.
 (setq hass-apikey (lambda () (auth-source-pass-get 'secret "home/hass/emacs-apikey")))
 #+END_SRC
 
-The ~hass-entity~ variable is used when the ~hass-query-all-entities~ function is called. It should
-contain a list of strings of entity ID's for each entity you want included.
+Once those variables are set, you must call ~(hass-setup)~ before using this package so that it can
+query the Home Assistance instance and populate available entities and services.
 
 ** Getting an API Key
 
@@ -94,27 +95,28 @@ cumbersome. Here's what the encoded list above looks like in JSON:
 }
 #+END_SRC
 
-** Auto-query
+** Watching entities
 
-Auto-querying is a recurring query to the Home Assistant instance to get the current state of some
-entities. The list of entity IDs that will be queried are found in the variable ~hass-auto-entities~.
+~hass-watch-mode~ is a mode that periodically queries the Home Assistant instance to get the current
+state of a list of entities. The list of entity IDs that will be queried are found in the variable
+~hass-watch-entities~.
 
 #+BEGIN_SRC emacs-lisp :results none
-(setq hass-auto-entities '("switch.bedroom_light" "switch.bedroom_fan"))
+(setq hass-watch-entities '("switch.bedroom_light" "switch.bedroom_fan"))
 #+END_SRC
 
-The frequency of the query can be adjusted by setting ~hass-auto-query-frequency~ to the number of
+The frequency of the query can be adjusted by setting ~hass-watch-frequency~ to the number of
 seconds you'd like. Defaults to 60.
 
-Auto-querying is most useful with the function hass-entity-state-updated-functions~ explained
-in the [[*Hooks][Hooks]] section.
+Watching is most useful with the function ~hass-entity-state-updated-functions~ explained in the
+[[*Hooks][Hooks]] section.
 
 ** Hooks
 
 The most useful hook is a function list named ~hass-entity-state-updated-functions~. Functions in
 this list are passed a single argument ~entity-id~ which is the entity id of the entity whose state
-has changed since it was last updated. Using this function hook along side [[*Auto-query][auto-querying]] enables
-Emacs to react to changes to Home Assistant entities.
+has changed since it was last updated. Using this function hook along side [[*Watching
+entities][watching entities]] enables Emacs to react to changes to Home Assistant entities.
 
 This example will display the state of an entity when it changes:
 

--- a/hass.el
+++ b/hass.el
@@ -20,7 +20,7 @@
   :group 'hass
   :prefix "hass-")
 
-(defvar hass-mode-map (make-sparse-keymap)
+(defvar hass-watch-mode-map (make-sparse-keymap)
   "Keymap for hass mode.")
 
 

--- a/hass.el
+++ b/hass.el
@@ -59,7 +59,7 @@ something like *switch.bedroom_light*."
 Each function is called with one arguments: the ENTITY-ID of the
 entity whose state changed.")
 
-(defvar hass-entity-state-updated-hook nil
+(defvar hass-entity-state-refreshed-hook nil
  "Hook called after an entity state data was received.")
 
 (defvar hass-service-called-hook nil
@@ -171,7 +171,7 @@ ENTITY-ID is the id of the entity that has STATE."
     (setf (alist-get entity-id hass--states nil nil 'string-match-p) state)
     (unless (equal previous-state state)
       (run-hook-with-args 'hass-entity-state-updated-functions entity-id)))
-  (run-hooks 'hass-entity-state-updated-hook))
+  (run-hooks 'hass-entity-state-refreshed-hook))
 
 (defun hass--call-service-result (entity-id state)
   "Callback when a successful service request is received from API.

--- a/hass.el
+++ b/hass.el
@@ -20,11 +20,11 @@
   :group 'hass
   :prefix "hass-")
 
+
+;; Customizable
 (defvar hass-watch-mode-map (make-sparse-keymap)
   "Keymap for hass mode.")
 
-
-;; Customizable
 (defcustom hass-url nil
   "The URL of the Home Assistant instance.
 Set this to the URL of the Home Assistant instance you want to

--- a/hass.el
+++ b/hass.el
@@ -39,7 +39,7 @@ requests"
   :group 'hass
   :type 'string)
 
-(defcustom hass-watched-entities nil
+(defcustom hass-watch-entities nil
   "A list of tracked Home Assistant entities.
 Set this to a list of Home Assistant entity ID strings.  An entity ID looks
 something like *switch.bedroom_light*."
@@ -306,7 +306,7 @@ Use the variable `hass-watch-frequency' to change how
 frequently (in seconds) the Home Assistant instance should be
 queried.
 
-Use the variable `hass-watched-entities' to set which entities you want
+Use the variable `hass-watch-entities' to set which entities you want
 to query automatically."
   :lighter nil
   :group 'hass
@@ -328,7 +328,7 @@ to query automatically."
 
 (defun hass-watch--query-entities ()
   "Update the current state all of the registered entities."
-  (dolist (entity hass-watched-entities)
+  (dolist (entity hass-watch-entities)
     (hass--get-entity-state entity)))
 
 

--- a/hass.el
+++ b/hass.el
@@ -289,7 +289,9 @@ SUCCESS-CALLBACK is a function to be called with a successful request response."
   (hass--call-service
    service
    payload
-   (lambda (&rest _) (run-hooks 'hass-service-called-hook) (when success-callback (funcall success-callback)))))
+   (lambda (&rest _)
+     (run-hooks 'hass-service-called-hook)
+     (when success-callback (funcall success-callback)))))
 
 
 ;; Watching

--- a/hass.el
+++ b/hass.el
@@ -235,8 +235,7 @@ list of entity-ids."
          (when callback (funcall callback))))))
 
 (defun hass--get-entity-state (entity-id)
-  "Retrieve the current state of ENTITY-ID from the Home Assistant server.
-This function is just for sending the actual API request."
+  "Retrieve the current state of ENTITY-ID from the Home Assistant server."
   (hass--request "GET" (hass--entity-url entity-id)
     (cl-function
       (lambda (&key response &allow-other-keys)
@@ -245,7 +244,6 @@ This function is just for sending the actual API request."
 
 (defun hass--call-service (service payload &optional success-callback)
   "Call service SERVICE for ENTITY-ID on the Home Assistant server.
-This function is just for building and sending the actual API request.
 
 SERVICE is a string of the Home Assistant service to be called.
 

--- a/hass.el
+++ b/hass.el
@@ -39,7 +39,7 @@ requests"
   :group 'hass
   :type 'string)
 
-(defcustom hass-auto-entities nil
+(defcustom hass-watched-entities nil
   "A list of tracked Home Assistant entities.
 Set this to a list of Home Assistant entity ID strings.  An entity ID looks
 something like *switch.bedroom_light*."
@@ -47,13 +47,13 @@ something like *switch.bedroom_light*."
   :group 'hass
   :type '(repeat string))
 
-(defcustom hass-auto-query nil
+(defcustom hass-watch nil
   "Periodically query the state of the configured in HASS-ENTITIES."
   :group 'hass
   :type 'boolean)
 
-(defcustom hass-auto-query-frequency 60
-  "Amount of seconds between auto-querying HASS-ENTITIES."
+(defcustom hass-watch-frequency 60
+  "Amount of seconds between watching HASS-ENTITIES."
   :group 'hass
   :type 'integer)
 
@@ -300,45 +300,45 @@ SUCCESS-CALLBACK is a function to be called with a successful request response."
 
 
 ;; Auto query
-(defun hass-auto-query-toggle ()
+(defun hass-watch-toggle ()
   "Toggle querying Home Assistant periodically.
-Auto-querying is a way to periodically query the state of
+watching is a way to periodically query the state of
 entities you want to hook into to capture when their state
 changes.
 
-Use the variable `hass-auto-query-frequency' to change how
+Use the variable `hass-watch-frequency' to change how
 frequently (in seconds) the Home Assistant instance should be
 queried.
 
-Use the variable `hass-auto-entities' to set which entities you want
+Use the variable `hass-watched-entities' to set which entities you want
 to query automatically."
   (interactive)
-  (if hass-auto-query
-    (hass-auto-query-disable)
-    (hass-auto-query-enable)))
+  (if hass-watch
+    (hass-watch-disable)
+    (hass-watch-enable)))
 
-(defun hass-auto-query-enable ()
-  "Enable auto-query."
+(defun hass-watch-enable ()
+  "Enable watch."
   (unless hass-mode (user-error "Hass-mode must be enabled to use this feature"))
-  (when hass--timer (hass--auto-query-cancel))
-  (setq hass--timer (run-with-timer nil hass-auto-query-frequency 'hass-query-all-entities))
-  (setq hass-auto-query t))
+  (when hass--timer (hass--watch-cancel))
+  (setq hass--timer (run-with-timer nil hass-watch-frequency 'hass-query-watched-entities))
+  (setq hass-watch t))
 
-(defun hass-auto-query-disable ()
-  "Disable auto-query."
-  (hass--auto-query-cancel)
-  (setq hass-auto-query nil))
+(defun hass-watch-disable ()
+  "Disable watch."
+  (hass--watch-cancel)
+  (setq hass-watch nil))
 
-(defun hass--auto-query-cancel ()
-  "Cancel auto-query without disabling it."
+(defun hass--watch-cancel ()
+  "Cancel watch without disabling it."
   (when hass--timer
     (cancel-timer hass--timer)
     (setq hass--timer nil)))
 
-(defun hass-query-all-entities ()
+(defun hass-query-watched-entities ()
   "Update the current state all of the registered entities."
   (interactive)
-  (dolist (entity hass-auto-entities)
+  (dolist (entity hass-watched-entities)
     (hass--get-entity-state entity)))
 
 
@@ -357,9 +357,9 @@ Key bindings:
       (unless (equal (type-of hass-url) 'string)
           (hass-mode 0)
           (user-error "HASS-URL must be set to use hass-mode"))
-      (when hass-auto-query (hass-auto-query-enable))
+      (when hass-watch (hass-watch-enable))
       (hass--get-available-services))
-  (unless hass-mode (hass--auto-query-cancel)))
+  (unless hass-mode (hass--watch-cancel)))
 
 (provide 'hass)
 

--- a/hass.el
+++ b/hass.el
@@ -1,7 +1,7 @@
 ;;; hass.el --- Interact with Home Assistant -*- lexical-binding: t; -*-
 
 ;; Package-Requires: ((emacs "25.1") (request "0.3.3"))
-;; Version: 1.1.1
+;; Version: 1.2.0
 ;; Author: Ben Whitley
 ;;; Commentary:
 

--- a/hass.el
+++ b/hass.el
@@ -182,7 +182,6 @@ ENTITY-ID is the id of the entity that was affected and now has STATE."
 (cl-defun hass--request-error (&key error-thrown &allow-other-keys)
   "Error handler for invalid requests.
 ERROR-THROWN is the error thrown from the request.el request."
-
   (let ((error (cdr error-thrown)))
     (cond ((string= error "exited abnormally with code 7\n")
            (hass-mode 0)

--- a/hass.el
+++ b/hass.el
@@ -12,7 +12,7 @@
 ;; Homepage: https://github.com/purplg/hass
 
 ;;; Code:
-(require' json)
+(require 'json)
 (require 'request)
 
 (defgroup hass '()

--- a/hass.el
+++ b/hass.el
@@ -333,21 +333,15 @@ to query automatically."
 
 
 ;;;###autoload
-(define-minor-mode hass-mode
-  "Toggle Home Assistant mode.
-Key bindings:
-\\{hass-mode-map}"
-  :lighter nil
-  :group 'hass
-  :global t
-  (when hass-mode
-      (unless (equal (type-of (hass--apikey)) 'string)
-          (hass-mode 0)
-          (user-error "HASS-APIKEY must be set to use hass-mode"))
-      (unless (equal (type-of hass-url) 'string)
-          (hass-mode 0)
-          (user-error "HASS-URL must be set to use hass-mode"))
-      (hass--get-available-services 'hass--get-available-entities)))
+(defun hass-setup ()
+  "Run before using any hass features.
+Check whether necessary variables are set and then query the Home
+Assistant instance for available services and entities."
+  (cond ((not (equal (type-of (hass--apikey)) 'string))
+         (user-error "HASS-APIKEY must be set to use hass-mode"))
+        ((not (equal (type-of hass-url) 'string))
+         (user-error "HASS-URL must be set to use hass-mode"))
+        ((hass--get-available-services 'hass--get-available-entities))))
 
 (provide 'hass)
 


### PR DESCRIPTION
Some breaking changes:
- Removed `hass-mode`. Replaced with `hass-setup` which should be called before using package.
- Converted auto-querying functionality into its own mode, `hass-watch-mode`.
- Renamed hook `hass-entity-state-updated-hook` to `hass-entity-state-refreshed-hook` for clarity.