### PR TITLE
Websocket fix

### DIFF
--- a/README.org
+++ b/README.org
@@ -69,7 +69,7 @@ The ~hass-url~ variable is now deprecated. This has been split up into 3 variabl
 (hass-setup)
 #+END_SRC
 
-This change was implemented to support the ~hass-websockets~ extension package. This uses a different protocol and splitting out the URL into components makes it much easier to generate the websocket URL automatically.
+This change was implemented to support the ~hass-websockets~ extension. This uses a different protocol and splitting out the URL into components makes it much easier to generate the websocket URL automatically.
 
 The package will currently parse ~hass-url~ if it is set and convert it into its appropriate configuration variables. This will be removed in the future.
 
@@ -187,7 +187,7 @@ To retrieve automatic updates of specific entities, you must configure the ~hass
 
 Then you can enable either ~hass-websocket-mode~ or ~hass-polling-mode~.
 
-~hass-websocket-mode~ is a mode that receives updates from Home Assistant over websockets. This enables realtime updates to entity states. Highly recommended if using the dashboard feature.
+~hass-websocket-mode~, requires =websocket= package, is a mode that receives updates from Home Assistant over a websocket. This enables real-time updates to entity states. Highly recommended if using the dashboard feature.
 
 #+BEGIN_SRC emacs-lisp :results none
 (hass-websocket-mode t)

--- a/hass-websocket.el
+++ b/hass-websocket.el
@@ -1,7 +1,7 @@
 ;;; hass-websocket.el --- Communicate with Home Assistant over websockets -*- lexical-binding: t; -*-
 
 ;; Package-Requires: ((emacs "25.1") (hass "2.0.0") (websocket "1.12"))
-;; Version: 1.0.0
+;; Version: 1.0.1
 ;; Author: Ben Whitley
 ;; SPDX-License-Identifier: MIT
 ;; Homepage: https://github.com/purplg/hass

--- a/hass-websocket.el
+++ b/hass-websocket.el
@@ -56,7 +56,8 @@
 ;;; Code:
 (require 'hass)
 (require 'json)
-(require 'websocket)
+(unless (require 'websocket nil 'noerror)
+  (user-error "`hass-websockets-mode' requires package `websocket'"))
 
 ;; User customizable
 (defvar hass-websocket-mode-map (make-sparse-keymap)

--- a/hass.el
+++ b/hass.el
@@ -1,7 +1,7 @@
 ;;; hass.el --- Interact with Home Assistant -*- lexical-binding: t; -*-
 
 ;; Package-Requires: ((emacs "25.1") (request "0.3.3"))
-;; Version: 2.1.1
+;; Version: 2.1.2
 ;; Author: Ben Whitley
 ;; Homepage: https://github.com/purplg/hass
 ;; SPDX-License-Identifier: MIT


### PR DESCRIPTION
- Fix: Check for `websocket` package before loading `hass-websocket`.
- Updated README