### PR TITLE
Fix random 400 errors in tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,7 @@ test:
 start-homeassistant:
 	docker run -d --rm -p 8123:8123 --name ${docker-name} ${docker-name} && \
 	timeout 10 bash -c "until curl http://localhost:8123/api/ --silent > /dev/null ; do sleep 0.2 ; done"
+	sleep 1
 
 .PHONY: build-homeassistant
 build-homeassistant:


### PR DESCRIPTION
- Added a 1 second sleep after detecting Home Assistant container is up